### PR TITLE
build: rewrite imports from lib to es6 in es6 output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -3043,6 +3049,81 @@
         "resolve-cwd": "^2.0.0"
       }
     },
+    "import-path-rewrite": {
+      "version": "github:gcanti/import-path-rewrite#0086599732ccc761a33255a702a07266895d0572",
+      "from": "github:gcanti/import-path-rewrite",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "glob": "^7.1.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3098,9 +3179,9 @@
       "integrity": "sha512-6i8PKyNR/dvEbUU9uE+v4iVFU7l674ZEGQsh92y6xEZF/rj46fXbPy+uPPXJEsCP0J0X3UpzXAxp04K4HR2jVw=="
     },
     "io-ts-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.0.tgz",
-      "integrity": "sha512-+v88rlA76FmlQQcTImFq5iigoPA3OKO+BIdrpsfXlhWUdiVvOnDDiLKCsiIAW9eRj+OJgG31Sctebr77bqKhzw=="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.7.tgz",
+      "integrity": "sha512-3AN63MewxiYhJeQ+/RirPMbAM3DBn2tv2VOCHG2dc1DZOzM2JmH87TxJukfIbWICcJ0aYvncz0nAV7jverCkcQ=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prettier": "prettier --list-different \"./src/**/*.ts\"",
     "prettier:fix": "prettier --write \"./src/**/*.ts\"",
     "prepublishOnly": "npm run test && npm run build",
+    "postbuild": "import-path-rewrite",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "version": "npm run changelog && git add CHANGELOG.md"
   },
@@ -22,6 +23,7 @@
     "@devexperts/lint": "^0.29.1",
     "@types/jest": "^22.2.3",
     "conventional-changelog-cli": "^2.0.21",
+    "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.0",
     "prettier": "^1.17.1",
@@ -34,7 +36,7 @@
   "dependencies": {
     "fp-ts": "^2.0.0",
     "io-ts": "^2.0.0",
-    "io-ts-types": "^0.5.0",
+    "io-ts-types": "^0.5.7",
     "tslib": "^1.9.3"
   },
   "repository": {

--- a/src/remote-data-io.ts
+++ b/src/remote-data-io.ts
@@ -1,6 +1,6 @@
 import { RemoteData, RemoteFailure, RemoteInitial, RemotePending, RemoteProgress, RemoteSuccess } from './remote-data';
 import { optionFromNullable } from 'io-ts-types/lib/optionFromNullable';
-import { literal, number, type, Type, union } from 'io-ts';
+import { literal, number, type, Type, union } from 'io-ts/lib/index';
 
 export type JSONRemoteProgress = {
 	loaded: number;

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./es6",
+    "target": "es6",
     "module": "es6"
   }
 }


### PR DESCRIPTION
Closes https://github.com/devexperts/remote-data-ts/issues/46
Closes https://github.com/devexperts/remote-data-ts/issues/49

### Changes

- I've copied the `postbuild` step and `tsconfig.es6.json` change from https://github.com/gcanti/fp-ts-rxjs/commit/f35c926d5bea5a91c5af1c8b152031edfb423a90
- `io-ts-types` had to be updated. The `es6` folder was added in version 0.5.4.
- In `src/remote-data-io.ts`, an import had to be changed to allow `import-path-rewrite` to rewrite it.

### Testing
I tested this on a fairly large codebase, by rewriting code that used used `Either` and the `fp-ts/es6/...` imports to use `RemoteData` imported from `@devexperts/remote-data-ts/es6/remote-data`, and it worked well. `webpack-bundle-analyzer` indicates that only `es6` parts are bundled, and as far as I can tell only the modules that are in use are included (both from `fp-ts` and `remote-data-ts`)

I did **not** test the `remote-data-io` and `remote-data-t` parts of the library, as I am not familiar with `io-ts` and monad transformers. But I inspected the generated .js and .d.ts in `/dist` and `/es6`. The output looks correct, and all the imports resolve correctly.

Let me know if you have any better ideas for testing this change!