### PR TITLE
Add RefreshableRemoteData functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -611,10 +611,13 @@
       }
     },
     "@types/jest": {
-      "version": "22.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
-      "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
-      "dev": true
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^24.3.0"
+      }
     },
     "@types/minimist": {
       "version": "1.2.0",
@@ -3278,6 +3281,7 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
+        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "@devexperts/lint": "^0.29.1",
-    "@types/jest": "^22.2.3",
+    "@types/jest": "^24.9.1",
     "conventional-changelog-cli": "^2.0.21",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",

--- a/src/__tests__/refreshable-remote-data.spec.ts
+++ b/src/__tests__/refreshable-remote-data.spec.ts
@@ -1,0 +1,80 @@
+import { failure, getShow, initial, pending, success as successRD } from '../remote-data';
+import { RefreshableRemoteData, staleIfError, staleWhileRevalidate } from '../refreshable-remote-data';
+import { fst, snd } from 'fp-ts/lib/Tuple';
+import { showString } from 'fp-ts/lib/Show';
+import { flow } from 'fp-ts/lib/function';
+const show = flow(getShow(showString, showString).show);
+
+type TestRRD = RefreshableRemoteData<string, string>;
+type TestMatrix = Array<[TestRRD, TestRRD]>;
+
+describe('RemoteData', () => {
+	const failcur = failure('Current failure');
+	const failnxt = failure('Next failure');
+	const succcur = successRD('Current success');
+	const succnxt = successRD('Next success');
+
+	describe('Strategy: staleWhileRevalidate', () => {
+		const matrix: TestMatrix = [
+			[[initial, initial], [initial, initial]],
+			[[initial, pending], [pending, pending]],
+			[[initial, failnxt], [failnxt, initial]],
+			[[initial, succnxt], [succnxt, initial]],
+
+			[[pending, initial], [pending, initial]],
+			[[pending, pending], [pending, pending]],
+			[[pending, failnxt], [failnxt, initial]],
+			[[pending, succnxt], [succnxt, initial]],
+
+			[[failcur, initial], [failcur, initial]],
+			[[failcur, pending], [pending, pending]],
+			[[failcur, failnxt], [failnxt, initial]],
+			[[failcur, succnxt], [succnxt, initial]],
+
+			[[succcur, initial], [succcur, initial]],
+			[[succcur, pending], [succcur, pending]],
+			[[succcur, failnxt], [failnxt, initial]],
+			[[succcur, succnxt], [succnxt, initial]],
+		];
+
+		matrix.forEach(([input, expected]) => {
+			it(formatTestName(input, expected), () => {
+				expect(staleWhileRevalidate(input)).toStrictEqual(expected);
+			});
+		});
+	});
+
+	describe('Strategy: staleIfError', () => {
+		const matrix: TestMatrix = [
+			[[initial, initial], [initial, initial]],
+			[[initial, pending], [pending, pending]],
+			[[initial, failnxt], [failnxt, initial]],
+			[[initial, succnxt], [succnxt, initial]],
+
+			[[pending, initial], [pending, initial]],
+			[[pending, pending], [pending, pending]],
+			[[pending, failnxt], [failnxt, initial]],
+			[[pending, succnxt], [succnxt, initial]],
+
+			[[failcur, initial], [failcur, initial]],
+			[[failcur, pending], [failcur, pending]],
+			[[failcur, failnxt], [failnxt, initial]],
+			[[failcur, succnxt], [succnxt, initial]],
+
+			[[succcur, initial], [succcur, initial]],
+			[[succcur, pending], [succcur, pending]],
+			[[succcur, failnxt], [succcur, initial]],
+			[[succcur, succnxt], [succnxt, initial]],
+		];
+
+		matrix.forEach(([input, expected]) => {
+			it(formatTestName(input, expected), () => {
+				expect(staleIfError(input)).toStrictEqual(expected);
+			});
+		});
+	});
+});
+
+function formatTestName(input: TestRRD, expected: TestRRD) {
+	return `[${show(fst(input))}, ${show(snd(input))}] -> [${show(fst(expected))}, ${show(snd(expected))}]`;
+}

--- a/src/refreshable-remote-data.ts
+++ b/src/refreshable-remote-data.ts
@@ -1,0 +1,60 @@
+import { pipe } from 'fp-ts/lib/pipeable';
+import { failure, fold, initial, isFailure, isInitial, isSuccess, RemoteData, success } from './remote-data';
+
+/**
+ * When refreshing a resource it can be desirable to do so silently in the background while keeping
+ * the previously fetched value around until the new value is ready.
+ *
+ * The {@link RefreshableRemoteData} type can express this by using a tuple of {@link RemoteData}
+ * types, where
+ *
+ * 1. The first value represents the cached (stale) value that represents the latest loaded data
+ * 2. The second value represents the background request that will refresh (revalidate) the cache
+ */
+export type RefreshableRemoteData<E, A> = [
+	RemoteData<E, A> /** Current state (cache) */,
+	RemoteData<E, A> /** Next state (revalidation request) */,
+];
+
+/**
+ * Given a {@link RefreshableRemoteData}, the stale-while-revalidate refresh strategy will
+ *
+ * - return an initial or pending value as long as no data has been fetched
+ * - keep returning a success value until it is replaced by another success or failure value
+ * - keep returning a failure value only as long as it is not being refreshed, in which case
+ *   it will fall back to a pending value
+ *
+ * @see {@link staleIfError}
+ */
+export function staleWhileRevalidate<E, A>([current, next]: RefreshableRemoteData<E, A>): RefreshableRemoteData<E, A> {
+	return pipe(
+		next,
+		fold(
+			() => [current, next],
+			() => [isInitial(current) || isFailure(current) ? next : current, next],
+			e => [failure(e), initial],
+			x => [success(x), initial],
+		),
+	);
+}
+
+/**
+ * Given a {@link RefreshableRemoteData}, the stale-if-error refresh strategy will
+ *
+ * - return an initial or pending value as long as no data has been fetched
+ * - return a failure only if no data has been previously fetched; newer failures replace older ones
+ * - keep returning the cached success value indefinitely unless it is replaced by another success value
+ *
+ * @see {@link staleWhileRevalidate}
+ */
+export function staleIfError<E, A>([current, next]: RefreshableRemoteData<E, A>): RefreshableRemoteData<E, A> {
+	return pipe(
+		next,
+		fold(
+			() => [current, next],
+			() => [isInitial(current) ? next : current, next],
+			e => [isSuccess(current) ? current : failure(e), initial],
+			x => [success(x), initial],
+		),
+	);
+}


### PR DESCRIPTION
This PR adds functionality to refresh a `RemoteData` type as discussed in #22.

## Proposal

### A `RefreshableRemoteData` type

A tuple modeled after the discussion in https://github.com/krisajenkins/remotedata/issues/9, where

1. The first value represents the cached (stale) value that represents the latest loaded data
2. The second value represents the background request that will refresh (revalidate) the cache

```ts
export type RefreshableRemoteData<E, A> = [ RemoteData<E, A>, RemoteData<E, A> ];
```

### A stale-while-revalidate strategy

Given a `RefreshableRemoteData`, the _stale-while-revalidate_ refresh strategy will

- return an initial or pending value as long as no data has been fetched
- keep returning a success value until it is replaced by another success or failure value
- keep returning a failure value only as long as it is not being refreshed, in which case it will fall back to a pending value

### A stale-if-error strategy

Given a `RefreshableRemoteData`, the _stale-if-error_ refresh strategy will

- return an initial or pending value as long as no data has been fetched
- return a failure only if no data has been previously fetched; newer failures replace older ones
- keep returning the cached success value indefinitely unless it is replaced by another success value

## Discussion

As stated in #22, this functionality might not be desired and should be kept in the UI layer instead of here, in the data model. A major reason being that the subtleties of the various state transitions could be different for each app. I'm completely fine with that, should the decision be to reject this PR.

Still, as I have needed this myself several times and because others have expressed this need as well, I thought that if we don't introduce a fully new data type (`RefreshableRemoteData` being just a shortcut type for `Tuple<RemoteData, RemoteData>`) but a series of combinators, that would

1. provide a useful baseline
2. be extensible with new combinators if the need arises
3. lead to a collection of update strategies that might be interesting for users of the library to choose from and discuss

This could also be a separate library, but as there is not currently an ecosystem around remote-data-ts (that I know of), and because it seems to me to be a useful part of the core, I proposed this as a PR here.

