### PR TITLE
RemoteDataM3 extends URIS3 instead

### DIFF
--- a/src/remote-data-t.ts
+++ b/src/remote-data-t.ts
@@ -115,7 +115,7 @@ export interface RemoteDataM2<M extends URIS2> extends ApplicativeComposition22<
 
 export type RemoteDataT3<M extends URIS3, S, R, E, A> = Kind3<M, S, R, RemoteData<E, A>>;
 
-export interface RemoteDataM3<M extends URIS4> {
+export interface RemoteDataM3<M extends URIS3> {
 	readonly map: <S, R, E, A, B>(fa: RemoteDataT3<M, S, R, E, A>, f: (a: A) => B) => RemoteDataT3<M, S, R, E, B>;
 	readonly of: <S, R, E, A>(a: A) => RemoteDataT3<M, S, R, E, A>;
 	readonly ap: <S, R, E, A, B>(


### PR DESCRIPTION
A typing issue from this lib started showing up on our codebase after importing the `ReaderObservableEither` from [`fp-ts-rxjs`](https://github.com/gcanti/fp-ts-rxjs).

```
Type 'M' does not satisfy the constraint '"ReaderObservableEither" | "ReaderEither" | "ReaderTaskEither"'.
  Type '"StateReaderTaskEither"' is not assignable to type '"ReaderObservableEither" | "ReaderEither" | "ReaderTaskEither"'.
    Type 'M' is not assignable to type '"ReaderTaskEither"'.
      Type '"StateReaderTaskEither"' is not assignable to type '"ReaderTaskEither"'.
```

After looking a bit into it, I've found that the `M` generic from `RemoteDataM3` was extending `URIS4` and looking at the other ones it seems it should be extending `URIS3` instead, which fixes the issue on our end. Although I'm not entirely sure of what that means, looking forward to any feedback of what this means. 