### PR TITLE
Support for import without lib or es6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /.idea
 /node_modules
 /dist
-/es6

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -614,6 +624,12 @@
       "version": "22.2.3",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
       "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
       "dev": true
     },
     "@types/minimist": {
@@ -749,6 +765,12 @@
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2522,9 +2544,10 @@
       }
     },
     "fp-ts": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.2.tgz",
-      "integrity": "sha512-ZCeu5MkqNDBWe1ewjZQ9Q9JNcPKEKXpitYzJ4ygCWpfJ3skW3imZ45EqsZd+9N8rkBvmsb64ToZTI2xXNO9IcQ=="
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.10.5.tgz",
+      "integrity": "sha512-X2KfTIV0cxIk3d7/2Pvp/pxL/xr2MV1WooyEzKtTWYSc1+52VF4YzjBTXqeOlSiZsPCxIBpDGfT9Dyo7WEY0DQ==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3102,9 +3125,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -3278,6 +3301,7 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
+        "fp-ts": "^2.0.0",
         "glob": "^7.1.6"
       },
       "dependencies": {
@@ -3398,12 +3422,14 @@
     "io-ts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.0.tgz",
-      "integrity": "sha512-6i8PKyNR/dvEbUU9uE+v4iVFU7l674ZEGQsh92y6xEZF/rj46fXbPy+uPPXJEsCP0J0X3UpzXAxp04K4HR2jVw=="
+      "integrity": "sha512-6i8PKyNR/dvEbUU9uE+v4iVFU7l674ZEGQsh92y6xEZF/rj46fXbPy+uPPXJEsCP0J0X3UpzXAxp04K4HR2jVw==",
+      "dev": true
     },
     "io-ts-types": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.7.tgz",
-      "integrity": "sha512-3AN63MewxiYhJeQ+/RirPMbAM3DBn2tv2VOCHG2dc1DZOzM2JmH87TxJukfIbWICcJ0aYvncz0nAV7jverCkcQ=="
+      "integrity": "sha512-3AN63MewxiYhJeQ+/RirPMbAM3DBn2tv2VOCHG2dc1DZOzM2JmH87TxJukfIbWICcJ0aYvncz0nAV7jverCkcQ==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -6130,10 +6156,32 @@
         }
       }
     },
+    "ts-node": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.8.2.tgz",
+      "integrity": "sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.18.0",
@@ -6578,6 +6626,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
   "typings": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc -p ./tsconfig.build.json && tsc -p ./tsconfig.es6.json",
+    "build": "tsc -p ./tsconfig.build.json && tsc -p ./tsconfig.es6.json && npm run import-path-rewrite && ts-node scripts/build",
     "test": "npm run tslint && npm run prettier && npm run jest",
     "tslint": "tslint -c tslint.json --project tsconfig.json './src/**/*.ts'",
     "jest": "jest",
-    "prettier": "prettier --list-different \"./src/**/*.ts\"",
-    "prettier:fix": "prettier --write \"./src/**/*.ts\"",
-    "prepublishOnly": "npm run test && npm run build",
-    "postbuild": "import-path-rewrite",
+    "prettier": "prettier --list-different \"./{src,scripts}/**/*.ts\"",
+    "prettier:fix": "prettier --write \"./{src,scripts}/**/*.ts\"",
+    "prepublishOnly": "ts-node scripts/pre-publish",
+    "prerelease": "npm run build",
+    "import-path-rewrite": "import-path-rewrite",
+    "release": "ts-node scripts/release",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "version": "npm run changelog && git add CHANGELOG.md"
   },
@@ -21,23 +23,28 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "@devexperts/lint": "^0.29.1",
+    "@types/glob": "^7.1.3",
     "@types/jest": "^22.2.3",
     "conventional-changelog-cli": "^2.0.21",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.0",
+    "fp-ts": "^2.5.0",
+    "glob": "^7.1.7",
+    "io-ts": "^2.0.0",
+    "io-ts-types": "^0.5.7",
     "prettier": "^1.17.1",
     "ts-jest": "^23.10.5",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^1.3.0",
+    "ts-node": "8.8.2",
     "typescript": "^3.5.2"
   },
-  "dependencies": {
+  "peerDependencies": {
     "fp-ts": "^2.0.0",
     "io-ts": "^2.0.0",
-    "io-ts-types": "^0.5.7",
-    "tslib": "^1.9.3"
+    "io-ts-types": "^0.5.7"
   },
   "repository": {
     "type": "git",

--- a/scripts/FileSystem.ts
+++ b/scripts/FileSystem.ts
@@ -1,0 +1,29 @@
+import * as TE from 'fp-ts/lib/TaskEither';
+import { flow } from 'fp-ts/lib/function';
+import * as fs from 'fs';
+import G from 'glob';
+
+export interface FileSystem {
+	readonly readFile: (path: string) => TE.TaskEither<Error, string>;
+	readonly writeFile: (path: string, content: string) => TE.TaskEither<Error, void>;
+	readonly copyFile: (from: string, to: string) => TE.TaskEither<Error, void>;
+	readonly glob: (pattern: string) => TE.TaskEither<Error, ReadonlyArray<string>>;
+	readonly mkdir: (path: string) => TE.TaskEither<Error, void>;
+}
+
+const readFile = TE.taskify<fs.PathLike, string, NodeJS.ErrnoException, string>(fs.readFile);
+const writeFile = TE.taskify<fs.PathLike, string, NodeJS.ErrnoException, void>(fs.writeFile);
+const copyFile = TE.taskify<fs.PathLike, fs.PathLike, NodeJS.ErrnoException, void>(fs.copyFile);
+const glob = TE.taskify<string, Error, ReadonlyArray<string>>(G);
+const mkdirTE = TE.taskify(fs.mkdir);
+
+export const fileSystem: FileSystem = {
+	readFile: path => readFile(path, 'utf8'),
+	writeFile,
+	copyFile,
+	glob,
+	mkdir: flow(
+		mkdirTE,
+		TE.map(() => undefined),
+	),
+};

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,85 @@
+import * as path from 'path';
+import * as E from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as RTE from 'fp-ts/lib/ReaderTaskEither';
+import * as A from 'fp-ts/lib/ReadonlyArray';
+import * as TE from 'fp-ts/lib/TaskEither';
+import { FileSystem, fileSystem } from './FileSystem';
+import { run } from './run';
+
+interface Build<A> extends RTE.ReaderTaskEither<FileSystem, Error, A> {}
+
+const OUTPUT_FOLDER = 'dist';
+const PKG = 'package.json';
+
+export const copyPackageJson: Build<void> = C =>
+	pipe(
+		C.readFile(PKG),
+		TE.chain(s => TE.fromEither(E.parseJSON(s, E.toError))),
+		TE.map(v => {
+			const clone = Object.assign({}, v as any);
+
+			delete clone.scripts;
+			delete clone.files;
+			delete clone.devDependencies;
+
+			return clone;
+		}),
+		TE.chain(json => C.writeFile(path.join(OUTPUT_FOLDER, PKG), JSON.stringify(json, null, 2))),
+	);
+
+export const FILES: ReadonlyArray<string> = ['CHANGELOG.md', 'LICENSE', 'README.md'];
+
+export const copyFiles: Build<ReadonlyArray<void>> = C =>
+	A.readonlyArray.traverse(TE.taskEither)(FILES, from => C.copyFile(from, path.resolve(OUTPUT_FOLDER, from)));
+
+const traverse = A.readonlyArray.traverse(TE.taskEither);
+
+export const makeModules: Build<void> = C =>
+	pipe(
+		C.glob(`${OUTPUT_FOLDER}/lib/*.js`),
+		TE.map(getModules),
+		TE.chain(modules => traverse(modules, makeSingleModule(C))),
+		TE.map(() => undefined),
+	);
+
+function getModules(paths: ReadonlyArray<string>): ReadonlyArray<string> {
+	return paths.map(filePath => path.basename(filePath, '.js')).filter(x => x !== 'index');
+}
+
+function makeSingleModule(C: FileSystem): (module: string) => TE.TaskEither<Error, void> {
+	return m =>
+		pipe(
+			C.mkdir(path.join(OUTPUT_FOLDER, m)),
+			TE.chain(() => makePkgJson(m)),
+			TE.chain(data => C.writeFile(path.join(OUTPUT_FOLDER, m, 'package.json'), data)),
+		);
+}
+
+function makePkgJson(module: string): TE.TaskEither<Error, string> {
+	return pipe(
+		JSON.stringify(
+			{
+				main: `../lib/${module}.js`,
+				module: `../es6/${module}.js`,
+				typings: `../lib/${module}.d.ts`,
+				sideEffects: false,
+			},
+			null,
+			2,
+		),
+		TE.right,
+	);
+}
+
+const main: Build<void> = pipe(
+	copyPackageJson,
+	RTE.chain(() => copyFiles),
+	RTE.chain(() => makeModules),
+);
+
+run(
+	main({
+		...fileSystem,
+	}),
+);

--- a/scripts/pre-publish.ts
+++ b/scripts/pre-publish.ts
@@ -1,0 +1,6 @@
+import { left } from 'fp-ts/lib/TaskEither';
+import { run } from './run';
+
+const main = left(new Error('"npm publish" can not be run from root, run "npm run release" instead'));
+
+run(main);

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,23 @@
+import { run } from './run';
+import * as child_process from 'child_process';
+import { left, right } from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
+
+const DIST = 'dist';
+
+const exec = (cmd: string, args?: child_process.ExecOptions): TE.TaskEither<Error, void> => () =>
+	new Promise(resolve => {
+		child_process.exec(cmd, args, err => {
+			if (err !== null) {
+				return resolve(left(err));
+			}
+
+			return resolve(right(undefined));
+		});
+	});
+
+export const main = exec('npm publish', {
+	cwd: DIST,
+});
+
+run(main);

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -1,0 +1,21 @@
+import { fold } from 'fp-ts/lib/Either';
+import { TaskEither } from 'fp-ts/lib/TaskEither';
+
+export function run<A>(eff: TaskEither<Error, A>): void {
+	eff()
+		.then(
+			fold(
+				e => {
+					throw e;
+				},
+				_ => {
+					process.exitCode = 0;
+				},
+			),
+		)
+		.catch(e => {
+			console.error(e); // tslint:disable-line no-console
+
+			process.exitCode = 1;
+		});
+}

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "./es6",
+    "outDir": "dist/es6",
     "target": "es6",
     "module": "es6"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,14 @@
     "moduleResolution": "node",
     "target": "es5",
     "lib": ["es6", "dom"],
-    "outDir": "dist",
+    "outDir": "dist/lib",
     "declaration": true,
     "strict": true,
     "importHelpers": true,
     "pretty": true,
     "noUnusedLocals": true,
-    "noEmitOnError": true
+    "noEmitOnError": true,
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
PR for #55.

What has changed:

* Build `scripts` and dependencies were copied from [retry-ts](https://github.com/gcanti/retry-ts)
* `fp-ts` and other dependencies moved to `peerDependencies`.
* Releasing the library is now possible via `npm run release`. An error message is presented when `npm publish` is used.