### PR TITLE
Fix invalid main and typings path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@devexperts/remote-data-ts",
   "version": "2.1.0",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "module": "es6/index.js",
-  "typings": "dist/index.d.ts",
+  "typings": "lib/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json && tsc -p ./tsconfig.es6.json && npm run import-path-rewrite && ts-node scripts/build",


### PR DESCRIPTION
In the current version `2.1.0` is a bug if you want to import the module directly via `import * as RD from '@devexperts/remote-data-ts';` which will result in a type error cause the typings can not be found in the old `dist` location. This problem was introduced by me in PR #65.